### PR TITLE
fix: url 协议跟随页面导航栏

### DIFF
--- a/src/util/huadiao-tool.js
+++ b/src/util/huadiao-tool.js
@@ -7,7 +7,7 @@
 'use strict';
 
 import {apis} from "@/assets/js/constants/request-path";
-import {HUADIAO_HOST_IP} from "@/util/request";
+import {HUADIAO_HOST} from "@/util/request";
 
 export const userAvatarImagePath = `${apis.imageHost}userAvatar/`;
 
@@ -64,7 +64,7 @@ export function huadiaoNickname(nickname, userId) {
 }
 
 export function huadiaoImageLink(imgName) {
-    return `http://${HUADIAO_HOST_IP}/images/${imgName}`;
+    return `${HUADIAO_HOST}/images/${imgName}`;
 }
 
 export function huadiaoEmoteLink(emoteName) {

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -6,10 +6,12 @@
 // 使用严格模式
 'use strict';
 
-import axios, {HttpStatusCode} from "axios";
+import axios from "axios";
 import {statusCode} from "@/assets/js/constants/status-code";
 
 export const HUADIAO_HOST_IP = process.env.VUE_APP_HUADIAO_HOST_IP;
+export const HTTP_PROTOCOL = window.location.protocol;
+export const HUADIAO_HOST = `${HTTP_PROTOCOL}//${HUADIAO_HOST_IP}`;
 
 const excludeInterceptors = [
     /\//,
@@ -31,23 +33,9 @@ function isExcludeInterceptors(pathname) {
     return false;
 }
 
-axios.interceptors.response.use((resp) => {
-    if (resp.status === HttpStatusCode.Ok) {
-        // 未登录跳转主页
-        if (resp.data.code === statusCode.NOT_AUTHORITATIVE && !isExcludeInterceptors(window.location.pathname)) {
-            window.location.href = "/";
-        }
-        // 页面不存在
-        else if (resp.data.code === statusCode.PAGE_NOT_EXIST) {
-            window.location.href = "/error/404";
-        }
-    }
-    return resp;
-});
-
 export function createAxios(config = {}) {
     const instance = axios.create({
-        baseURL: "http://" + HUADIAO_HOST_IP + "/huadiao",
+        baseURL: `${HUADIAO_HOST}/huadiao`,
         timeout: 10000,
         withCredentials: true,
 


### PR DESCRIPTION
- fix：修复请求 URL 无法跟随页面导航栏的协议变化
之前的由于写死请求协议 Http，在请求时浏览器会禁止这种跨协议的请求，因为这也算一种跨域。